### PR TITLE
Fix file paths with ToSourceName()

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ https://user-images.githubusercontent.com/12881812/163437857-7d42e4f6-4533-4c68-
 
 ## Disclaimer
 
-Please be aware that the 'free' Quixel tier is for use with Unreal Engine only. 
-This tool should only be used with either the 'Personal', 'Indie', or 'Studio' Quixel tiers. 
+Please be aware that the 'free' Quixel tier is for use with Unreal Engine only.
+This tool should only be used with either the 'Personal', 'Indie', or 'Studio' Quixel tiers.
 More information about these is located [here](https://quixel.com/pricing).
 
 I am not affiliated with Quixel, Epic Games, or Facepunch.

--- a/code/BridgeImporter.cs
+++ b/code/BridgeImporter.cs
@@ -90,7 +90,7 @@ public class BridgeImporter
 				if ( cat == "3d" || cat == "2d" || cat == "surface" )
 					continue;
 
-				path += $"{cat}/";
+				path += $"{cat.ToSourceName()}/";
 			}
 
 			path = path.NormalizePath();
@@ -134,7 +134,7 @@ public class BridgeImporter
 		// Create destination directories
 		Directory.CreateDirectory( path );
 
-		var assetPath = $"{path}/assets";
+		var assetPath = $"{path}assets";
 		Directory.CreateDirectory( assetPath );
 
 		void CopyAssets<T>( List<T> items, QuixelAsset asset, string subDir ) where T : IBaseAsset
@@ -146,12 +146,13 @@ public class BridgeImporter
 			{
 				T item = items[i];
 				string destination = item.Path.Replace( asset.Path, joinedSubDir );
+				destination = destination.Replace( item.Name, item.Name.ToSourceName() );
 
 				Directory.CreateDirectory( Path.GetDirectoryName( destination ) );
 				File.Copy( item.Path, destination, true );
 
 				item.Path = destination;
-				item.Name = item.Name.ToLower();
+				item.Name = item.Name.ToSourceName();
 
 				items[i] = item;
 			}
@@ -174,9 +175,9 @@ public class BridgeImporter
 
 	private static bool CreateMaterial( QuixelAsset quixelAsset )
 	{
-		var vmatPath = $"{quixelAsset.Path}/materials/";
+		var vmatPath = $"{quixelAsset.Path}materials/";
 		Directory.CreateDirectory( vmatPath );
-		vmatPath += $"/{quixelAsset.Name.ToSourceName()}_{quixelAsset.Id}.vmat";
+		vmatPath += $"{quixelAsset.Name.ToSourceName()}_{quixelAsset.Id}.vmat";
 
 		var baseVmat = new Template( "templates/Material.template" );
 		var pairs = new Dictionary<string, string>
@@ -234,8 +235,8 @@ public class BridgeImporter
 
 	private static bool CreateModel( QuixelAsset quixelAsset, int meshIndex )
 	{
-		var vmatPath = $"{quixelAsset.Path.PathRelativeTo( ProjectPath )}/materials/{quixelAsset.Name.ToSourceName()}_{quixelAsset.Id}.vmat";
-		var vmdlPath = $"{quixelAsset.Path}/{quixelAsset.Name.ToSourceName()}_{quixelAsset.Id}.vmdl";
+		var vmatPath = $"{quixelAsset.Path.PathRelativeTo( ProjectPath )}materials/{quixelAsset.Name.ToSourceName()}_{quixelAsset.Id}.vmat";
+		var vmdlPath = $"{quixelAsset.Path}{quixelAsset.Name.ToSourceName()}_{quixelAsset.Id}.vmdl";
 
 		var meshes = "";
 		var lods = "";

--- a/code/Templates/Lod.template
+++ b/code/Templates/Lod.template
@@ -1,7 +1,7 @@
 ﻿{
 	_class = "LODGroup"
 	switch_threshold = <#= Threshold #>
-	meshes = 
+	meshes =
 	[
 		"<#= Mesh #>",
 	]

--- a/code/Templates/Material.template
+++ b/code/Templates/Material.template
@@ -7,7 +7,7 @@ Layer0
 	//---- Metalness ----
 	F_METALNESS_TEXTURE 1
 	TextureMetalness "<#= Metallic #>"
-	
+
 	//---- Ambient Occlusion ----
 	F_AMBIENT_OCCLUSION_TEXTURE 1
 	TextureAmbientOcclusion "<#= AmbientOcclusion #>"

--- a/code/Templates/Mesh.template
+++ b/code/Templates/Mesh.template
@@ -2,7 +2,7 @@
     _class = "RenderMeshFile"
     filename = "<#= Mesh #>"
     import_scale = <#= Scale #>
-    import_filter = 
+    import_filter =
     {
         exclude_by_default = false
         exception_list = [  ]

--- a/code/Templates/Model.template
+++ b/code/Templates/Model.template
@@ -1,20 +1,20 @@
 ﻿<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:modeldoc28:version{fb63b6ca-f435-4aa0-a2c7-c66ddc651dca} -->
 {
-	rootNode = 
+	rootNode =
 	{
 		_class = "RootNode"
-		children = 
+		children =
 		[
 			{
 				_class = "LODGroupList"
-				children = 
+				children =
 				[
 					<#= Lods #>
 				]
 			},
 			{
 				_class = "MaterialGroupList"
-				children = 
+				children =
 				[
 					{
 						_class = "DefaultMaterialGroup"
@@ -26,14 +26,14 @@
 			},
 			{
 				_class = "RenderMeshList"
-				children = 
+				children =
 				[
 					<#= Meshes #>
 				]
 			},
 			{
 				_class = "PhysicsShapeList"
-				children = 
+				children =
 				[
 					{
 						_class = "PhysicsHullFromRender"


### PR DESCRIPTION
Some models like this Japanese wooden lamp ( https://quixel.com/assets/vevjfb3qx ) generate paths with spaces and Uppercase characters, things the Source Engine doesn't like.

At the time of export from Quixel the process works as intended, but the things break if you open the new assets in modeldoc or in the material editor.
this should fix that

also some paths in the final assets contained some // in the paths, the things seems to work fine with that, but it bothers me to see that in modeldoc and the material editor so fixed that too.

Aaannnd.... also deleted a couple of trailing spaces in some files.