### PR TITLE
Improved decals and simplified shader complex template.

### DIFF
--- a/code/BridgeImporter.cs
+++ b/code/BridgeImporter.cs
@@ -158,8 +158,11 @@ public class BridgeImporter
 			}
 		}
 
-		CopyAssets( quixelAsset.Meshes, quixelAsset, "meshes" );
-		CopyAssets( quixelAsset.LODs, quixelAsset, "meshes" );
+		if ( quixelAsset.Meshes.Count > 0 )
+		{
+			CopyAssets( quixelAsset.Meshes, quixelAsset, "meshes" );
+			CopyAssets( quixelAsset.LODs, quixelAsset, "meshes" );
+		}
 		CopyAssets( quixelAsset.Textures, quixelAsset, "textures" );
 
 		//
@@ -201,7 +204,7 @@ public class BridgeImporter
 			// Metallic should be 0 by default
 			{ "Metallic", "[0.000000 0.000000 0.000000 0.000000]" },
             
-            // Displasment (for the parallax of decals)
+			// Displasment (for the parallax of decals)
 			{ "Displacement", "[1.000000 1.000000 1.000000 0.000000]" }
 		};
 

--- a/code/BridgeImporter.cs
+++ b/code/BridgeImporter.cs
@@ -203,7 +203,7 @@ public class BridgeImporter
 
 			// Metallic should be 0 by default
 			{ "Metallic", "[0.000000 0.000000 0.000000 0.000000]" },
-            
+
 			// Displasment (for the parallax of decals)
 			{ "Displacement", "[1.000000 1.000000 1.000000 0.000000]" }
 		};

--- a/code/BridgeImporter.cs
+++ b/code/BridgeImporter.cs
@@ -199,7 +199,10 @@ public class BridgeImporter
 			{ "Translucency", "[1.000000 1.000000 1.000000 0.000000]" },
 
 			// Metallic should be 0 by default
-			{ "Metallic", "[0.000000 0.000000 0.000000 0.000000]" }
+			{ "Metallic", "[0.000000 0.000000 0.000000 0.000000]" },
+            
+            // Displasment (for the parallax of decals)
+			{ "Displacement", "[1.000000 1.000000 1.000000 0.000000]" }
 		};
 
 		// Get all used textures
@@ -227,6 +230,8 @@ public class BridgeImporter
 					pairs["Translucency"] = path;
 					break;
 				case "displacement":
+					pairs["Displacement"] = path;
+					break;
 				case "transmission":
 					// TODO
 					break;

--- a/code/SettingsWindow/SettingsWindow.cs
+++ b/code/SettingsWindow/SettingsWindow.cs
@@ -163,7 +163,7 @@ public class TestWindow : Window
 		var dict = new Dictionary<string, string>();
 
 		dict["ProjectPath"] = BridgeImporter.ProjectPath;
-		dict["ExportDirectory"] = BridgeImporter.ExportDirectory;
+		dict["ExportDirectory"] = BridgeImporter.ExportDirectory.ToSourceName();
 		dict["ServerPort"] = BridgeImporter.ServerPort.ToString();
 		dict["Scale"] = BridgeImporter.Scale.ToString();
 		dict["LodIncrement"] = BridgeImporter.LodIncrement.ToString();

--- a/code/Templates/Materials/Complex.template
+++ b/code/Templates/Materials/Complex.template
@@ -4,24 +4,19 @@ Layer0
 {
 	shader "complex.vfx"
 
-	//---- Metalness ----
+	//---- PBR ----
 	F_METALNESS_TEXTURE 1
-	TextureMetalness "<#= Metallic #>"
+	F_SPECULAR 1
 
 	//---- Ambient Occlusion ----
-	F_AMBIENT_OCCLUSION_TEXTURE 1
+	g_flAmbientOcclusionDirectDiffuse "0.000"
+	g_flAmbientOcclusionDirectSpecular "0.000"
 	TextureAmbientOcclusion "<#= AmbientOcclusion #>"
 
 	//---- Color ----
 	g_flModelTintAmount "1.000"
 	g_vColorTint "[1.000000 1.000000 1.000000 0.000000]"
 	TextureColor "<#= Diffuse #>"
-
-	//---- Normal ----
-	TextureNormal "<#= Normal #>"
-
-	//---- Roughness ----
-	TextureRoughness "<#= Roughness #>"
 
 	//---- Fade ----
 	g_flFadeExponent "1.000"
@@ -32,6 +27,15 @@ Layer0
 	//---- Lighting ----
 	g_flDirectionalLightmapMinZ "0.050"
 	g_flDirectionalLightmapStrength "1.000"
+
+	//---- Metalness ----
+	TextureMetalness "<#= Metallic #>"
+
+	//---- Normal ----
+	TextureNormal "<#= Normal #>"
+
+	//---- Roughness ----
+	TextureRoughness "<#= Roughness #>"
 
 	//---- Texture Coordinates ----
 	g_nScaleTexCoordUByModelScaleAxis "0"

--- a/code/Templates/Materials/Decal.template
+++ b/code/Templates/Materials/Decal.template
@@ -4,6 +4,12 @@ Layer0
 {
 	shader "projected_decals.vfx"
 
+	//---- Normal ----
+	F_NORMAL_MAP 1
+
+	//---- Parallax Occlusion ----
+	F_PARALLAX 1
+
 	//---- Metalness ----
 	F_METALNESS_TEXTURE 1
 	TextureMetalness "<#= Metallic #>"
@@ -35,6 +41,13 @@ Layer0
 	//---- Lighting ----
 	g_flDirectionalLightmapMinZ "0.050"
 	g_flDirectionalLightmapStrength "1.000"
+
+	//---- Parallax ----
+	g_flHeightMapScale "0.020"
+	g_nLODThreshold "4"
+	g_nMaxSamples "32"
+	g_nMinSamples "8"
+	TextureHeight "<#= Displacement #>"
 
 	//---- Texture Coordinates ----
 	g_nScaleTexCoordUByModelScaleAxis "0"

--- a/code/Templates/Materials/Decal.template
+++ b/code/Templates/Materials/Decal.template
@@ -10,30 +10,11 @@ Layer0
 	//---- Parallax Occlusion ----
 	F_PARALLAX 1
 
-	//---- Metalness ----
-	F_METALNESS_TEXTURE 1
-	TextureMetalness "<#= Metallic #>"
-
 	//---- Ambient Occlusion ----
-	F_AMBIENT_OCCLUSION_TEXTURE 1
 	TextureAmbientOcclusion "<#= AmbientOcclusion #>"
 
-	//---- Translucent ----
-	F_ALPHA_TEST 1
-
 	//---- Color ----
-	g_flModelTintAmount "1.000"
-	g_vColorTint "[1.000000 1.000000 1.000000 0.000000]"
 	TextureColor "<#= Diffuse #>"
-
-	//---- Normal ----
-	TextureNormal "<#= Normal #>"
-
-	//---- Roughness ----
-	TextureRoughness "<#= Roughness #>"
-
-	//---- Fade ----
-	g_flFadeExponent "1.000"
 
 	//---- Fog ----
 	g_bFogEnabled "1"
@@ -42,6 +23,12 @@ Layer0
 	g_flDirectionalLightmapMinZ "0.050"
 	g_flDirectionalLightmapStrength "1.000"
 
+	//---- Metalness ----
+	TextureMetalness "<#= Metallic #>"
+
+	//---- Normal ----
+	TextureNormal "<#= Normal #>"
+
 	//---- Parallax ----
 	g_flHeightMapScale "0.020"
 	g_nLODThreshold "4"
@@ -49,15 +36,9 @@ Layer0
 	g_nMinSamples "8"
 	TextureHeight "<#= Displacement #>"
 
-	//---- Texture Coordinates ----
-	g_nScaleTexCoordUByModelScaleAxis "0"
-	g_nScaleTexCoordVByModelScaleAxis "0"
-	g_vTexCoordOffset "[0.000 0.000]"
-	g_vTexCoordScale "[1.000 1.000]"
-	g_vTexCoordScrollSpeed "[0.000 0.000]"
+	//---- Roughness ----
+	TextureRoughness "<#= Roughness #>"
 
 	//---- Translucent ----
-	g_flAlphaTestReference "0.010"
-	g_flAntiAliasedEdgeStrength "0.000"
 	TextureTranslucency "<#= Translucency #>"
 }


### PR DESCRIPTION
c3229eaeb8e11c7057358dc7c8a8a8e4eddb313d Improved the path of the export directory to make sure the name of the folder doesn't have capitals or spaces.

c3229eaeb8e11c7057358dc7c8a8a8e4eddb313d Fixed the use of normals on the decals shader, the normals texture was there but it was not being used at all, and implemented the parallax of the shader.

I noticed some empty folders were being created, that was because we create the folders even if we dont have actual assets to put in them, thats fixed in 6fc6b2742efdef4c614721230debdb9929af32aa

Just like with the normal map in the decals we need to "turn on" some parameters on the complex shader to the metalness texture work, that's fixed not with 3645ad163326b5619bef30da4d501d0ce7ade29c, also deleted some parameters not used, and reformatted the template to look the same as the generated by the material editor.

531bfcd54a96f84ff2b5652ac618f64a8309bbe9 Deleted a bunch of unused stuff in the decals template, and reformated to look the same as generated by the material editor.