### PR TITLE
Fix compile error

### DIFF
--- a/.addon
+++ b/.addon
@@ -10,5 +10,7 @@
   "ResourcePaths": null,
   "HasCode": true,
   "CodePath": "/code/",
+  "PackageReferences": [],
+  "EditorReferences": null,
   "Metadata": {}
 }

--- a/code/BridgeImporter.cs
+++ b/code/BridgeImporter.cs
@@ -31,7 +31,8 @@ public class BridgeImporter
 				var mdlPath = Path.Join( relativePath, $"{quixelAsset.Name.ToSourceName()}_{quixelAsset.Id}.vmdl" );
 
 				// Locate imported s&box asset
-				var engineAsset = AssetSystem.All.FirstOrDefault( x => x.Path.NormalizeFilename() == mdlPath.NormalizeFilename() );
+				var assets = AssetSystem.All.ToList();
+				var engineAsset = assets.FirstOrDefault( x => x.Path.NormalizeFilename() == mdlPath.NormalizeFilename() );
 
 				if ( engineAsset == null )
 				{

--- a/code/Progress/ProgressWindow.cs
+++ b/code/Progress/ProgressWindow.cs
@@ -53,7 +53,6 @@ public class ProgressWindow : Window
 		base.DoLayout();
 
 		Content.Size = Size;
-		Content.Height = Content.Children.Where( x => x.Visible ).Sum( x => MathF.Max( x.SizeHint.y, x.MinimumSize.y ) + 1 ) - 1;
 
 		Content.Position = new Vector2( 0, MenuWidget.Height );
 		Size = Content.Position + Content.Size + new Vector2( 0, 4 );


### PR DESCRIPTION
I have never used this addon before, so I just made it work. I have no clue how ProgressWindow is supposed to show, but even with setting the height manually, I wasn't seeing the window. But it works and imports the assets.

- Fix compile error (Widget.SizeHint is no longer accessible)
- Fix task exception caused by AssetSystem.All collection being modified during enumeration