### PR TITLE
Upgraded legacy shader paths

### DIFF
--- a/code/Templates/Materials/Complex.template
+++ b/code/Templates/Materials/Complex.template
@@ -2,7 +2,7 @@
 
 Layer0
 {
-	shader "complex.vfx"
+	shader "shaders/complex.shader"
 
 	//---- PBR ----
 	F_METALNESS_TEXTURE 1
@@ -24,10 +24,6 @@ Layer0
 	//---- Fog ----
 	g_bFogEnabled "1"
 
-	//---- Lighting ----
-	g_flDirectionalLightmapMinZ "0.050"
-	g_flDirectionalLightmapStrength "1.000"
-
 	//---- Metalness ----
 	TextureMetalness "<#= Metallic #>"
 
@@ -35,6 +31,7 @@ Layer0
 	TextureNormal "<#= Normal #>"
 
 	//---- Roughness ----
+	g_flRoughnessScaleFactor "1.000"
 	TextureRoughness "<#= Roughness #>"
 
 	//---- Texture Coordinates ----

--- a/code/Templates/Materials/Decal.template
+++ b/code/Templates/Materials/Decal.template
@@ -2,7 +2,7 @@
 
 Layer0
 {
-	shader "projected_decals.vfx"
+	shader "shaders/projected_decals.shader"
 
 	//---- Normal ----
 	F_NORMAL_MAP 1
@@ -18,10 +18,6 @@ Layer0
 
 	//---- Fog ----
 	g_bFogEnabled "1"
-
-	//---- Lighting ----
-	g_flDirectionalLightmapMinZ "0.050"
-	g_flDirectionalLightmapStrength "1.000"
 
 	//---- Metalness ----
 	TextureMetalness "<#= Metallic #>"


### PR DESCRIPTION
- Upgraded legacy shader pats from the old " *.vfx " to the new " shaders/*.shader ".
- Deleted Lighting section, as its removed on recompile by the material editor.